### PR TITLE
[FIX#118382] Mauvais type sur un champ

### DIFF
--- a/src/ChangeTodos.php
+++ b/src/ChangeTodos.php
@@ -16,7 +16,7 @@ class ChangeTodos implements \JsonSerializable
     /* @var array $datas */
     private $datas;
 
-    /* @var integer $request_type */
+    /* @var string $request_type */
     private $request_type;
 
     /* @var integer $user_request_id */


### PR DESCRIPTION
On corrige un mauvais typage sur le champ `request_type` et scrutinizer n'est pas content